### PR TITLE
Fix greeting typo in displaydata

### DIFF
--- a/src/displaydata.php
+++ b/src/displaydata.php
@@ -17,7 +17,7 @@ if(isset($_GET['aid']) )
   	$aid = $_GET['aid'];
 
  $con = mysqli_connect("127.0.0.1","groot","bose123$","bankdb");
-echo "hello Wordls";
+echo "hello World";
  if($con->connect_errno)
  	{
 	echo $con->connect_error;


### PR DESCRIPTION
## Summary
- fix typo "Wordls" to "World" for correct greeting in displaydata

## Testing
- `php -l src/displaydata.php`


------
https://chatgpt.com/codex/tasks/task_e_688e0ac660988324b0ca72140bb91549