### PR TITLE
Fix two bugs found deploying to the lab VM

### DIFF
--- a/laravel/docker-entrypoint.sh
+++ b/laravel/docker-entrypoint.sh
@@ -64,6 +64,18 @@ done
 # has to be specific about consequences rather than vaguely cautionary,
 # because "be careful" is not actionable and gets ignored.
 # -----------------------------------------------------------------------------
+# Hand the writable trees back to www-data.
+#
+# Every artisan command above runs as ROOT (the container's default user), and
+# the first one to log creates storage/logs/laravel.log owned root:root. Apache
+# workers run as www-data and then cannot append to it, so ANY request that
+# logs anything -- a warning, a handled exception -- dies with
+# "The stream or file ... could not be opened" and returns 500.
+#
+# That failure mode is nasty because it is invisible until something logs, and
+# the error it produces points at logging rather than at ownership.
+chown -R www-data:www-data storage bootstrap/cache 2>/dev/null || true
+
 CONTAINER_IPS="$(hostname -i 2>/dev/null || echo 'unknown')"
 
 cat <<BANNER

--- a/laravel/resources/views/auth/register.blade.php
+++ b/laravel/resources/views/auth/register.blade.php
@@ -26,7 +26,15 @@ async function doRegister(e) {
     if (MODE === 'xml') {
         // The legacy client built XML by string concatenation, so the fields
         // are injectable into the document itself. Preserved.
-        const xml = '<?xml version="1.0" encoding="UTF-8"?>'
+        //
+        // NOTE the split declaration below. Writing the XML declaration as one
+        // literal would put a bare left-angle-bracket-question-mark in this
+        // file, which Blade compiles into a PHP SHORT OPEN TAG -- a fatal
+        // syntax error on any host with short_open_tag=On, as the Debian
+        // php:8.3-apache image has. (This comment cannot spell it out either,
+        // for exactly the same reason.) A build concern, not a lesson: the XML
+        // sent to the server is byte-identical.
+        const xml = '<' + '?xml version="1.0" encoding="UTF-8"?' + '>'
             + '<root>'
             + '<name>' + v('name') + '</name>'
             + '<password>' + v('pwd') + '</password>'

--- a/laravel/tests/Feature/BladeShortOpenTagTest.php
+++ b/laravel/tests/Feature/BladeShortOpenTagTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * Guards against a deployment bug that local testing cannot catch.
+ *
+ * A literal `<?xml` (or any bare `<?`) inside a Blade template is parsed as a
+ * PHP SHORT OPEN TAG when the view is compiled. On a host with
+ * short_open_tag=Off it is harmless; on one with it On -- as the Debian
+ * php:8.3-apache image used by docker-compose has -- the compiled view is a
+ * fatal syntax error and the page returns 500.
+ *
+ * That asymmetry is exactly how this reached a deployed VM while every local
+ * test passed. Scanning the source is environment-independent, so this test
+ * fails on any machine rather than only on the unlucky ones.
+ *
+ * Not a lesson -- a build correctness check.
+ */
+class BladeShortOpenTagTest extends TestCase
+{
+    public function test_no_blade_template_contains_a_short_open_tag(): void
+    {
+        $offenders = [];
+
+        $dir = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(resource_path('views'))
+        );
+
+        foreach ($dir as $file) {
+            if (! $file->isFile() || ! str_ends_with($file->getFilename(), '.blade.php')) {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+
+            // Any `<?` that is not `<?php` and not `<?=` is a short open tag.
+            if (preg_match_all('/<\?(?!php\b|=)/', $contents, $m, PREG_OFFSET_CAPTURE)) {
+                foreach ($m[0] as [$match, $offset]) {
+                    $line = substr_count(substr($contents, 0, $offset), "\n") + 1;
+                    $offenders[] = str_replace(base_path().DIRECTORY_SEPARATOR, '', $file->getPathname()).':'.$line;
+                }
+            }
+        }
+
+        $this->assertSame([], $offenders, implode("\n", [
+            'Blade template(s) contain a bare `<?`, which compiles to a PHP short open tag',
+            'and is a fatal syntax error where short_open_tag=On (the Docker image).',
+            'Split it, e.g.  \'<\' + \'?xml ... ?\' + \'>\'  in JS.',
+            'Offenders: '.implode(', ', $offenders),
+        ]));
+    }
+}


### PR DESCRIPTION
Both bugs were invisible locally and only surfaced deploying to the phpvulnbank VM. 64 tests pass.

## 1. `storage/logs` owned by root — every logging request 500s

Each `artisan` command in the entrypoint runs as **root** (the container's default user), and the first one to log creates `storage/logs/laravel.log` owned `root:root`. Apache workers run as `www-data` and then cannot append, so **any** request that logs anything — a warning, a handled exception — died with `The stream or file ... could not be opened` and returned 500.

The entrypoint now hands `storage` and `bootstrap/cache` back to `www-data` before starting Apache.

This is a nasty failure mode: invisible until something logs, and the error it produces points at *logging* rather than at *ownership*.

## 2. A literal XML declaration in a Blade template is a PHP short open tag

Blade compiles the whole template, so the bare `<?` in `register.blade.php`'s XML declaration became a short open tag — a fatal syntax error, **but only where `short_open_tag=On`**. My local `php.ini-development` has it Off; the Debian `php:8.3-apache` image has it On.

That asymmetry is exactly how this passed 63 local tests and then 500'd on the VM.

### Regression test

`BladeShortOpenTagTest` scans the templates **as source**, rather than relying on the host's `short_open_tag` setting, so the whole class of bug fails everywhere instead of only on unlucky hosts.

It immediately earned its keep: it caught a second instance straight away — the comment I wrote *explaining* the fix contained a literal XML declaration and reintroduced the bug it was describing.

## Why local testing missed both

Worth noting for the record, since it's a gap in the test strategy rather than bad luck:

- The log-ownership bug needs Apache running as a **different user** from the one that ran the migrations. `php artisan test` runs everything as one user.
- The short-open-tag bug needs a host with `short_open_tag=On`.

Neither condition exists on a dev machine. Deploying to a real container was the only thing that would have found them — which is an argument for doing it earlier next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
