### PR TITLE
Stop the test suite from destroying a real database

### DIFF
--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -23,9 +23,28 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-        <env name="DB_URL" value=""/>
+        <!--
+            force="true" IS LOAD-BEARING. Do not remove it.
+
+            Without it, PHPUnit leaves an existing real environment variable
+            alone. So in any environment where the DB_ variables are actually
+            exported (the docker-compose container sets DB_CONNECTION=mysql),
+            the suite runs RefreshDatabase against the LIVE database and drops
+            every table in it.
+
+            That is exactly what happened on the lab VM. Running
+            `php artisan test` inside the deployed container wiped the seeded
+            bank data, and still reported 64 passing tests, because from the
+            suite's point of view nothing had gone wrong.
+
+            TestIsolationTest asserts this stays fixed.
+        -->
+        <env name="DB_CONNECTION" value="sqlite" force="true"/>
+        <env name="DB_DATABASE" value=":memory:" force="true"/>
+        <env name="DB_URL" value="" force="true"/>
+        <env name="DB_HOST" value="" force="true"/>
+        <env name="DB_USERNAME" value="" force="true"/>
+        <env name="DB_PASSWORD" value="" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/laravel/tests/Feature/TestIsolationTest.php
+++ b/laravel/tests/Feature/TestIsolationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Safety net: the suite must NEVER be pointed at a real database.
+ *
+ * Most tests here use RefreshDatabase, which drops and rebuilds every table.
+ * If the connection resolves to anything other than in-memory SQLite, running
+ * the suite DESTROYS whatever it is connected to -- and reports success while
+ * doing it, because from the suite's point of view nothing went wrong.
+ *
+ * That is not hypothetical. `php artisan test` inside the deployed container
+ * wiped the seeded bank data on the lab VM, because phpunit.xml declared
+ * DB_CONNECTION=sqlite without force="true" and the container exports
+ * DB_CONNECTION=mysql. PHPUnit left the real variable alone.
+ *
+ * This test fails loudly instead, before any damage is done.
+ */
+class TestIsolationTest extends TestCase
+{
+    public function test_suite_runs_against_in_memory_sqlite_only(): void
+    {
+        $driver = DB::connection()->getDriverName();
+        $database = DB::connection()->getDatabaseName();
+
+        $this->assertSame('sqlite', $driver, implode("\n", [
+            'REFUSING TO TRUST THIS RUN: the test suite is connected to a '.$driver.' database.',
+            'RefreshDatabase would drop every table in it.',
+            'Check that phpunit.xml sets DB_CONNECTION with force="true" -- without it,',
+            'an exported DB_CONNECTION (as docker-compose sets) wins.',
+        ]));
+
+        $this->assertSame(':memory:', $database,
+            'The suite must use an in-memory database, not the file at '.$database.'.');
+    }
+
+    public function test_no_real_database_host_is_configured(): void
+    {
+        $this->assertEmpty(
+            config('database.connections.mysql.host'),
+            'A MySQL host is still configured during tests; phpunit.xml should force DB_HOST empty.'
+        );
+    }
+}

--- a/laravel/tests/TestCase.php
+++ b/laravel/tests/TestCase.php
@@ -3,8 +3,73 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use RuntimeException;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * Refuse to run against anything but an in-memory SQLite database.
+     *
+     * WHY THIS IS HERE, and why phpunit.xml alone is not enough:
+     *
+     * Most tests in this suite use RefreshDatabase, which drops and rebuilds
+     * every table. Laravel resolves configuration from the REAL process
+     * environment before anything phpunit.xml declares, and PHPUnit's
+     * force="true" does not reliably beat an exported variable. So in the
+     * docker-compose container, which exports DB_CONNECTION=mysql,
+     * `php artisan test` ran RefreshDatabase against the LIVE lab database.
+     *
+     * It dropped every table, wiped the seeded bank data, and still reported
+     * 64 passing tests -- because from the suite's point of view nothing had
+     * gone wrong. That is the worst possible failure shape: destructive and
+     * silent.
+     *
+     * This check runs before parent::setUp(), so it fires before RefreshDatabase
+     * can touch anything. It fails closed: the run aborts instead of trusting
+     * the environment.
+     *
+     * Not a lesson. A safety interlock. See also TestIsolationTest.
+     */
+    protected function setUp(): void
+    {
+        $this->refuseNonSqliteDatabase();
+
+        parent::setUp();
+    }
+
+    private function refuseNonSqliteDatabase(): void
+    {
+        $connection = $_SERVER['DB_CONNECTION']
+            ?? $_ENV['DB_CONNECTION']
+            ?? (getenv('DB_CONNECTION') ?: 'sqlite');
+
+        if (in_array($connection, ['sqlite', 'testing'], true)) {
+            return;
+        }
+
+        throw new RuntimeException(implode("\n", [
+            '',
+            '=========================================================================',
+            ' TEST RUN ABORTED -- this suite would have destroyed a real database.',
+            '=========================================================================',
+            '',
+            " DB_CONNECTION is \"{$connection}\", not sqlite.",
+            '',
+            ' Most tests here use RefreshDatabase, which DROPS EVERY TABLE on the',
+            ' connection it is given. Running them now would wipe that database and',
+            ' still report success.',
+            '',
+            ' You are probably running inside the docker-compose container, which',
+            ' exports DB_CONNECTION=mysql for the application. Do not run the suite',
+            ' there against the live lab data. Either:',
+            '',
+            '   * run it on a checkout outside the container, or',
+            '   * override explicitly:  DB_CONNECTION=sqlite DB_DATABASE=:memory: \\',
+            '                             php artisan test',
+            '',
+            ' If you do wipe the lab, rebuild it with:',
+            '   docker compose exec app php artisan migrate:fresh --seed --force',
+            '',
+        ]));
+    }
 }


### PR DESCRIPTION
Running `php artisan test` inside the deployed container **dropped every table in the live lab database and reported 64 passing tests.**

Proven on the VM:

```
rows after reseed:         4
rows after running tests:  0
```

## Cause

Most tests use `RefreshDatabase`, which drops and rebuilds every table on whatever connection it is handed. `phpunit.xml` declared `DB_CONNECTION=sqlite` — but **Laravel resolves the real process environment first**, and docker-compose exports `DB_CONNECTION=mysql` for the application. So the suite pointed at MySQL and did exactly what it was designed to do.

## Why `force="true"` isn't the fix

I tried it first. Verified that an exported variable still wins over PHPUnit's forced `<env>`, because Laravel reads `$_SERVER`/`getenv` ahead of it. It's included anyway for environments where it does work, but it can't be relied on.

## The actual fix

An interlock in `Tests\TestCase::setUp()` that runs **before `parent::setUp()`**, and therefore before `RefreshDatabase` can touch anything. It **fails closed** — the run aborts with an explanation and a reseed command rather than trusting the environment:

```
=========================================================================
 TEST RUN ABORTED -- this suite would have destroyed a real database.
=========================================================================
```

Plus `TestIsolationTest` as a second line of defence, asserting the connection really is in-memory SQLite.

## Why this was worth fixing properly

The failure shape, not the bug itself. It was **destructive and silent** — nothing in the output suggested the suite had done anything other than pass. A note-to-self not to run tests in the container would have held right up until the next person did it.

Third bug found by deploying, after #19's two. All three shared a cause: they needed a real container to surface, and a dev machine structurally cannot reproduce them.

Suite is now 66 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
