### PR TITLE
Add OpenAPI spec and gate the navigation on session state

### DIFF
--- a/laravel/app/Http/Controllers/Api/V2/OpenApiController.php
+++ b/laravel/app/Http/Controllers/Api/V2/OpenApiController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api\V2;
+
+use App\Http\Controllers\Controller;
+use App\Support\OpenApiSpec;
+use Illuminate\Http\JsonResponse;
+
+class OpenApiController extends Controller
+{
+    /**
+     * GET /api/v2/openapi.json
+     *
+     * Served without authentication so students can load it into Postman,
+     * Burp, Insomnia or Swagger UI without setting anything up first.
+     *
+     * Worth noticing in its own right: this is a complete machine-readable
+     * inventory of every endpoint, including the webshell and the ungated
+     * admin actions. Real deployments leak exactly this (OWASP API9). Here it
+     * is intentional, because the map is the teaching material.
+     */
+    public function __invoke(): JsonResponse
+    {
+        return response()->json(
+            OpenApiSpec::toArray(),
+            200,
+            [],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+        );
+    }
+}

--- a/laravel/app/Support/OpenApiSpec.php
+++ b/laravel/app/Support/OpenApiSpec.php
@@ -1,0 +1,397 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * The OpenAPI 3.1 description of the v2 API.
+ *
+ * Hand-written rather than generated, because the useful part is not the shape
+ * of the requests -- it is the `x-vuln` annotation on each operation naming the
+ * lesson it carries and the authentication it deliberately does NOT enforce.
+ * A generator would produce the former and miss the latter entirely.
+ *
+ * Served unauthenticated at /api/v2/openapi.json. That is itself worth
+ * noticing: a complete, machine-readable inventory of every endpoint --
+ * including the webshell and the ungated admin actions -- handed to anyone who
+ * asks. Real deployments leak exactly this (OWASP API9, Improper Inventory
+ * Management). Here it is deliberate, because students need the map.
+ */
+class OpenApiSpec
+{
+    public static function toArray(): array
+    {
+        return [
+            'openapi' => '3.1.0',
+            'info' => [
+                'title' => 'PHPVulnBank API v2',
+                'version' => '1.0.0',
+                'summary' => 'Intentionally vulnerable retail banking API for security training.',
+                'description' => implode("\n", [
+                    '**WARNING: every endpoint here is deliberately flawed.**',
+                    '',
+                    'This API is a training lab. It contains unauthenticated remote code',
+                    'execution, arbitrary file read, SSRF and SQL injection. Never run it',
+                    'on a public address. See `SECURITY.md`.',
+                    '',
+                    'Each operation carries an `x-vuln` field listing the lessons it hosts.',
+                    'The full catalogue, including the correct fix for each, is in',
+                    '`docs/vulnerabilities.md`.',
+                    '',
+                    '### Authentication',
+                    '',
+                    'Session cookie. POST to `/api/v2/auth/login`, then send the cookie back.',
+                    'Endpoints accept **both** `application/json` and',
+                    '`application/x-www-form-urlencoded` -- that dual acceptance is itself',
+                    'VULN-10, since it is what makes the transfer endpoint forgeable from a',
+                    'cross-site form.',
+                    '',
+                    '### Note on `x-auth-enforced`',
+                    '',
+                    'Where this is `false`, the endpoint requires no authentication **and',
+                    'should**. Those are the broken-access-control lessons, not gaps in this',
+                    'document.',
+                ]),
+                'license' => ['name' => 'MIT', 'identifier' => 'MIT'],
+            ],
+            'servers' => [
+                ['url' => '/', 'description' => 'This instance'],
+            ],
+            'tags' => [
+                ['name' => 'Authentication'],
+                ['name' => 'Registration'],
+                ['name' => 'Accounts'],
+                ['name' => 'Transfers'],
+                ['name' => 'Feedback'],
+                ['name' => 'KYC'],
+                ['name' => 'Admin'],
+                ['name' => 'Tools', 'description' => 'Deliberate webshells. Unauthenticated by design.'],
+            ],
+            'components' => [
+                'securitySchemes' => [
+                    'sessionCookie' => [
+                        'type' => 'apiKey',
+                        'in' => 'cookie',
+                        'name' => 'laravel_session',
+                    ],
+                ],
+                'schemas' => [
+                    'Account' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'acno' => ['type' => 'integer'],
+                            'username' => ['type' => 'string'],
+                            'balance' => ['type' => 'integer'],
+                            'email' => ['type' => 'string'],
+                            'mobile' => ['type' => 'string'],
+                            'feedback' => ['type' => 'string'],
+                            'password_hash' => [
+                                'type' => 'string',
+                                'description' => 'Unsalted MD5. Returned deliberately (VULN-21).',
+                            ],
+                            'admin' => ['type' => 'integer'],
+                        ],
+                    ],
+                    'Error' => [
+                        'type' => 'object',
+                        'properties' => ['error' => ['type' => 'string']],
+                    ],
+                ],
+            ],
+            'paths' => self::paths(),
+        ];
+    }
+
+    private static function paths(): array
+    {
+        return [
+            '/api/v2/auth/login' => [
+                'post' => self::op(
+                    'Authentication', 'Log in',
+                    'Credentials are checked with an interpolated raw SQL statement. The password sits inside MySQL\'s MD5() call, so it is injectable too.',
+                    ['VULN-01 SQLi auth bypass', 'VULN-02 command-injection backdoor', 'VULN-14 reflected XSS', 'VULN-24 user enumeration', 'VULN-25 no rate limiting'],
+                    false,
+                    body: ['uname' => 'string', 'pwd' => 'string'],
+                    responses: [
+                        '200' => 'Authenticated, or on the backdoor path the output of a shell command.',
+                        '401' => 'Failure. Served as text/html with the submitted username reflected unescaped.',
+                    ],
+                    notes: "Try `uname=' or '1'='1' -- ` with any password.\nTry `uname=id&pwd=troy` for unauthenticated command execution."
+                ),
+            ],
+            '/api/v2/auth/logout' => [
+                'post' => self::op('Authentication', 'Log out', 'Invalidates the session.', [], true,
+                    responses: ['200' => 'Logged out.']),
+            ],
+            '/api/v2/register/json' => [
+                'post' => self::op(
+                    'Registration', 'Register (JSON body)',
+                    'The body is read raw and JSON-decoded regardless of the declared Content-Type, then passed to the model wholesale.',
+                    ['VULN-66 mass assignment', 'VULN-67 content-type confusion', 'VULN-06 SQLi', 'VULN-15 MD5 storage'],
+                    false,
+                    body: ['name' => 'string', 'pwd' => 'string', 'email' => 'string', 'tel' => 'string', 'admin' => 'integer', 'active' => 'integer'],
+                    responses: ['201' => 'Created.', '409' => 'Username taken (reflected as HTML).'],
+                    notes: 'Sending `"admin":1,"active":1` creates an activated administrator.'
+                ),
+            ],
+            '/api/v2/register/xml' => [
+                'post' => self::op(
+                    'Registration', 'Register (XML body)',
+                    'Parses the body with external entity resolution deliberately re-enabled.',
+                    ['VULN-09 XXE', 'VULN-06 SQLi'],
+                    false,
+                    rawBody: 'application/xml',
+                    responses: ['201' => 'Created.'],
+                    notes: 'A DOCTYPE with a SYSTEM entity pointing at file:///etc/passwd will be resolved and echoed back.'
+                ),
+            ],
+            '/api/v2/accounts/me' => [
+                'get' => self::op(
+                    'Accounts', 'Own account',
+                    'Looks the caller up by the username held in the session, interpolated into raw SQL.',
+                    ['VULN-06 second-order SQLi', 'VULN-13 stored XSS', 'VULN-21 hash disclosure'],
+                    true,
+                    responses: ['200' => 'Account, including the password hash and admin flag.', '401' => 'Not authenticated.']
+                ),
+            ],
+            '/api/v2/accounts/{acno}' => [
+                'get' => self::op(
+                    'Accounts', 'Look up any account',
+                    'No ownership check and no authentication. The account number is interpolated unquoted, so injection needs no quote breaking.',
+                    ['VULN-05 numeric SQLi', 'VULN-11 IDOR / BOLA', 'VULN-21 hash disclosure'],
+                    false,
+                    params: ['acno' => 'Account number. Route pattern is deliberately widened to `.*` so payloads reach the query.'],
+                    responses: ['200' => 'Username, password hash and balance.', '404' => 'No such account.'],
+                    notes: 'The table has nine columns: `0 union select 1,2,3,4,5,6,7,8,9`.'
+                ),
+            ],
+            '/api/v2/accounts/{acno}/safe' => [
+                'get' => self::op(
+                    'Accounts', 'Look up any account (remediated twin)',
+                    'Uses a bound parameter, so the injection is genuinely fixed. The missing ownership check and the password disclosure are NOT fixed -- patching one of three bugs is the lesson.',
+                    ['VULN-11 IDOR (still present)', 'VULN-21 hash disclosure (still present)'],
+                    false,
+                    params: ['acno' => 'Account number.'],
+                    responses: ['200' => 'Username, password hash and balance.', '404' => 'No such account.']
+                ),
+            ],
+            '/api/v2/transfers' => [
+                'post' => self::op(
+                    'Transfers', 'Transfer funds',
+                    'Accepts form-encoded bodies and authenticates from the session cookie, with no CSRF token required. Reads the balance, computes, and writes back without a transaction.',
+                    ['VULN-10 CSRF', 'VULN-16 negative amounts', 'VULN-17 race condition', 'VULN-11 IDOR', 'VULN-35 replay', 'VULN-06 SQLi'],
+                    true,
+                    body: ['tacno' => 'string', 'tamount' => 'string'],
+                    responses: ['200' => 'Transfer completed.', '401' => 'Not authenticated.'],
+                    notes: 'A negative amount reverses the direction and drains the destination. There is no overdraft check.'
+                ),
+            ],
+            '/api/v2/transfers/protected' => [
+                'post' => self::op(
+                    'Transfers', 'Transfer funds (remediated twin)',
+                    'Requires a CSRF token. Every other flaw -- injection, IDOR, negative amounts, the race -- survives untouched.',
+                    ['VULN-16', 'VULN-17', 'VULN-11', 'VULN-06'],
+                    true,
+                    body: ['tacno' => 'string', 'tamount' => 'string', 'csrftoken' => 'string'],
+                    responses: ['200' => 'Transfer completed.', '419' => 'Invalid CSRF token.']
+                ),
+            ],
+            '/api/v2/feedback/me' => [
+                'put' => self::op(
+                    'Feedback', 'Submit feedback',
+                    'Stores the text unvalidated and unescaped. No authentication guard: the session username is read without checking it exists.',
+                    ['VULN-13 stored XSS (store half)', 'VULN-12 missing authentication', 'VULN-06 SQLi'],
+                    false,
+                    body: ['fb' => 'string'],
+                    responses: ['200' => 'Updated.'],
+                    notes: 'This column is also the stored prompt-injection sink for the MCP layer (VULN-77).'
+                ),
+            ],
+            '/api/v2/feedback' => [
+                'get' => self::op(
+                    'Feedback', 'All customer feedback',
+                    'Admin-gated. Returns every customer\'s feedback raw; the browser client renders it with innerHTML.',
+                    ['VULN-13 stored XSS (render half)'],
+                    true,
+                    responses: ['200' => 'Feedback for all users.', '403' => 'Not admin.']
+                ),
+            ],
+            '/api/v2/kyc' => [
+                'post' => self::op(
+                    'KYC', 'Upload a KYC document',
+                    'No validation rules, no extension or MIME check, no size limit. The client-supplied filename is used verbatim and the file is written inside the document root.',
+                    ['VULN-04 unrestricted upload to RCE', 'VULN-12 missing authentication'],
+                    false,
+                    rawBody: 'multipart/form-data',
+                    responses: ['200' => 'Stored, with the public URL.'],
+                    notes: 'Upload a .php file and request it under /images/. The filename is also a traversal sink.'
+                ),
+            ],
+            '/api/v2/admin/pending-activations' => [
+                'get' => self::op(
+                    'Admin', 'List accounts awaiting activation',
+                    'Correctly admin-gated. Contrast with the activate action below -- that contrast is the lesson.',
+                    ['VULN-13 stored XSS'],
+                    true,
+                    responses: ['200' => 'Pending accounts.', '403' => 'Not admin.']
+                ),
+            ],
+            '/api/v2/admin/activate' => [
+                'post' => self::op(
+                    'Admin', 'Activate an account',
+                    'The FORM that reaches this is admin-gated. The ACTION is not gated at all, and needs no session. Gating the UI is not gating the endpoint.',
+                    ['VULN-12 missing function-level access control', 'VULN-06 SQLi', 'VULN-14 reflected XSS'],
+                    false,
+                    body: ['user' => 'string'],
+                    responses: ['200' => 'Activated (HTML, username reflected).'],
+                    notes: 'Chains with registration: create an account, then activate it yourself.'
+                ),
+            ],
+            '/api/v2/admin/kyc' => [
+                'get' => self::op(
+                    'Admin', 'List uploaded KYC documents',
+                    'Lists every document every customer has uploaded. Reachable without authentication -- the admin-only link was the only control.',
+                    ['VULN-12 missing access control'],
+                    false,
+                    responses: ['200' => 'Document names and download URLs.']
+                ),
+            ],
+            '/api/v2/admin/kyc/download' => [
+                'get' => self::op(
+                    'Admin', 'Download a KYC document',
+                    'The path is passed to the filesystem with no normalisation, allow-list or confinement.',
+                    ['VULN-07 path traversal / LFI', 'VULN-14 reflected XSS'],
+                    false,
+                    query: ['file' => 'Path to read. Not confined to the uploads directory.'],
+                    responses: ['200' => 'File contents.', '404' => 'Not found (path reflected).'],
+                    notes: 'Try `?file=../.env` to take the APP_KEY.'
+                ),
+            ],
+            '/api/v2/tools/exec' => [
+                'get' => self::op(
+                    'Tools', 'Execute a shell command',
+                    'An unauthenticated webshell. The command is passed to the system shell and its output returned. There is no safe version of this endpoint.',
+                    ['VULN-03 command injection'],
+                    false,
+                    query: ['cmd' => 'Command to execute.'],
+                    responses: ['200' => 'Command output as text/plain.']
+                ),
+                'post' => self::op(
+                    'Tools', 'Execute a shell command (POST)',
+                    'As above. Responding to both verbs is deliberate.',
+                    ['VULN-03 command injection', 'VULN-68 verb tampering'],
+                    false,
+                    body: ['cmd' => 'string'],
+                    responses: ['200' => 'Command output as text/plain.']
+                ),
+            ],
+            '/api/v2/tools/fetch' => [
+                'get' => self::op(
+                    'Tools', 'Fetch a URL server-side',
+                    'file_get_contents() on an unvalidated parameter, so every enabled stream wrapper is reachable. Errors are returned verbatim, making this an information-disclosure oracle as well.',
+                    ['VULN-08 SSRF'],
+                    false,
+                    query: ['url' => 'URL or path to fetch.'],
+                    responses: ['200' => 'Response body, or the error message.'],
+                    notes: 'Try `?url=http://169.254.169.254/` or `?url=file:///etc/passwd`.'
+                ),
+            ],
+            '/api/v2/openapi.json' => [
+                'get' => self::op(
+                    'Tools', 'This document',
+                    'A complete machine-readable inventory of every endpoint, served without authentication.',
+                    ['VULN-69 excessive information exposure (deliberate here)'],
+                    false,
+                    responses: ['200' => 'This OpenAPI document.']
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * Build one operation object.
+     */
+    private static function op(
+        string $tag,
+        string $summary,
+        string $description,
+        array $vulns,
+        bool $authEnforced,
+        array $params = [],
+        array $query = [],
+        array $body = [],
+        ?string $rawBody = null,
+        array $responses = [],
+        ?string $notes = null,
+    ): array {
+        $op = [
+            'tags' => [$tag],
+            'summary' => $summary,
+            'description' => $description.($notes ? "\n\n**How to reach it:**\n\n".$notes : ''),
+            'x-vuln' => $vulns,
+            'x-auth-enforced' => $authEnforced,
+        ];
+
+        if (! $authEnforced) {
+            $op['description'] .= "\n\n> **No authentication is enforced on this endpoint.** "
+                .'Where that is wrong, it is the lesson rather than an omission in this document.';
+        }
+
+        $parameters = [];
+
+        foreach ($params as $name => $desc) {
+            $parameters[] = [
+                'name' => $name, 'in' => 'path', 'required' => true,
+                'schema' => ['type' => 'string'], 'description' => $desc,
+            ];
+        }
+
+        foreach ($query as $name => $desc) {
+            $parameters[] = [
+                'name' => $name, 'in' => 'query', 'required' => true,
+                'schema' => ['type' => 'string'], 'description' => $desc,
+            ];
+        }
+
+        if ($parameters !== []) {
+            $op['parameters'] = $parameters;
+        }
+
+        if ($rawBody !== null) {
+            $op['requestBody'] = [
+                'required' => true,
+                'content' => [$rawBody => ['schema' => ['type' => 'string']]],
+            ];
+        } elseif ($body !== []) {
+            $props = [];
+            foreach ($body as $name => $type) {
+                $props[$name] = ['type' => $type];
+            }
+            $schema = ['type' => 'object', 'properties' => $props];
+
+            $op['requestBody'] = [
+                'required' => true,
+                'content' => [
+                    // Both are accepted. See VULN-10.
+                    'application/x-www-form-urlencoded' => ['schema' => $schema],
+                    'application/json' => ['schema' => $schema],
+                ],
+            ];
+        }
+
+        $op['responses'] = [];
+
+        foreach ($responses as $code => $desc) {
+            $op['responses'][(string) $code] = ['description' => $desc];
+        }
+
+        if ($op['responses'] === []) {
+            $op['responses']['200'] = ['description' => 'OK'];
+        }
+
+        if ($authEnforced) {
+            $op['security'] = [['sessionCookie' => []]];
+        }
+
+        return $op;
+    }
+}

--- a/laravel/resources/views/docs.blade.php
+++ b/laravel/resources/views/docs.blade.php
@@ -1,0 +1,92 @@
+@extends('layouts.app')
+
+@section('content')
+    <h2>API documentation</h2>
+
+    <p>
+        Machine-readable spec:
+        <a href="/api/v2/openapi.json"><code>/api/v2/openapi.json</code></a>
+        &mdash; load it into Postman, Insomnia or Burp.
+        Every operation carries an <code>x-vuln</code> field naming the lessons it hosts,
+        and <code>x-auth-enforced</code> showing whether authentication is actually required.
+    </p>
+
+    <div id="swagger-ui"></div>
+
+    {{-- Shown only if Swagger UI cannot be fetched, e.g. an air-gapped lab. --}}
+    <div id="fallback" style="display:none">
+        <h3>Endpoint reference</h3>
+        <p>
+            Swagger UI could not be loaded from the CDN &mdash; this instance has no
+            internet access. The spec itself is served locally and is unaffected;
+            the table below is generated from it.
+        </p>
+        <table id="fallback-table" border="1" cellpadding="6" cellspacing="0"
+               style="border-collapse:collapse;font-size:13px"></table>
+    </div>
+@endsection
+
+@section('scripts')
+{{--
+    Swagger UI is loaded from a CDN rather than bundled. That keeps the repo
+    free of a JS build step, which the api-refactor design doc argues for --
+    a bundler would also obscure the deliberate innerHTML sinks the XSS lessons
+    depend on.
+
+    The trade-off is that an isolated lab with no egress cannot fetch it, so the
+    page degrades to a table built from the local spec instead of showing
+    nothing. The spec endpoint never depends on the CDN.
+--}}
+<link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"
+        onerror="swaggerUnavailable()"></script>
+<script>
+function swaggerUnavailable() {
+    document.getElementById('swagger-ui').style.display = 'none';
+    document.getElementById('fallback').style.display = 'block';
+
+    fetch('/api/v2/openapi.json')
+        .then(r => r.json())
+        .then(spec => {
+            const rows = [['Method', 'Path', 'Auth enforced', 'Lessons']];
+            for (const [path, ops] of Object.entries(spec.paths)) {
+                for (const [method, op] of Object.entries(ops)) {
+                    rows.push([
+                        method.toUpperCase(),
+                        path,
+                        op['x-auth-enforced'] ? 'yes' : 'NO',
+                        (op['x-vuln'] || []).join(', ') || '—',
+                    ]);
+                }
+            }
+            // Built with textContent, not innerHTML -- this table is
+            // documentation, not one of the XSS lessons.
+            const table = document.getElementById('fallback-table');
+            rows.forEach((cells, i) => {
+                const tr = document.createElement('tr');
+                cells.forEach(c => {
+                    const cell = document.createElement(i === 0 ? 'th' : 'td');
+                    cell.textContent = c;
+                    tr.appendChild(cell);
+                });
+                table.appendChild(tr);
+            });
+        });
+}
+
+window.addEventListener('load', function () {
+    if (typeof SwaggerUIBundle === 'undefined') {
+        swaggerUnavailable();
+        return;
+    }
+
+    SwaggerUIBundle({
+        url: '/api/v2/openapi.json',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        tryItOutEnabled: true,
+        displayRequestDuration: true,
+    });
+});
+</script>
+@endsection

--- a/laravel/resources/views/layouts/app.blade.php
+++ b/laravel/resources/views/layouts/app.blade.php
@@ -31,14 +31,40 @@
 <body>
 <header><h1>Welcome to PHP VULN BANK</h1></header>
 
+{{--
+    The navigation is rendered from session state: signed-out visitors see only
+    Login and Register.
+
+    IMPORTANT -- this is a UI change ONLY, and it does not close any lesson.
+    The endpoints behind these links are exactly as reachable as before; several
+    of them (VULN-11 account lookup, VULN-12 activate, KYC list and download,
+    the tools endpoints) still require no authentication at all.
+
+    If anything this makes VULN-12 sharper rather than weaker. Previously the
+    links were visible to everyone, so "the UI is not a control" was easy to
+    assume. Now the interface genuinely looks gated -- and the endpoints still
+    are not. A learner has to notice that hiding a link changed nothing, which
+    is the entire point of broken function-level access control.
+
+    Do not be tempted to add middleware to the routes to "match" this nav.
+--}}
 <nav>
-    <a href="/">Login</a> |
-    <a href="/profile">Profile</a> |
-    <a href="/transfer">Transfer</a> |
-    <a href="/feedback">Feedback</a> |
-    <a href="/kyc">KYC Upload</a> |
-    <a href="/admin">Admin</a> |
-    <a href="/lookup">Account Lookup</a>
+    @if (session()->has('uname'))
+        <a href="/profile">Profile</a> |
+        <a href="/transfer">Transfer</a> |
+        <a href="/feedback">Feedback</a> |
+        <a href="/kyc">KYC Upload</a> |
+        <a href="/lookup">Account Lookup</a> |
+        <a href="/admin">Admin</a> |
+        <a href="/docs">API Docs</a> |
+        <a href="#" onclick="navSignout(event)">Signout</a>
+        <span style="margin-left:12px;color:#666">signed in as {{ session('uname') }}</span>
+    @else
+        <a href="/">Login</a> |
+        <a href="/register/json">Register (JSON)</a> |
+        <a href="/register/xml">Register (XML)</a> |
+        <a href="/docs">API Docs</a>
+    @endif
 </nav>
 
 <main>
@@ -89,6 +115,12 @@ function render(html) {
 function renderText(text) {
     // The safe counterpart, used for endpoints that are not XSS lessons.
     document.getElementById('out').textContent = text;
+}
+
+async function navSignout(e) {
+    e.preventDefault();
+    await fetch('/api/v2/auth/logout', { method: 'POST' });
+    window.location = '/';
 }
 
 async function api(method, url, body, form) {

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\V2\AdminController;
 use App\Http\Controllers\Api\V2\AuthController;
 use App\Http\Controllers\Api\V2\FeedbackController;
 use App\Http\Controllers\Api\V2\KycController;
+use App\Http\Controllers\Api\V2\OpenApiController;
 use App\Http\Controllers\Api\V2\RegisterController;
 use App\Http\Controllers\Api\V2\TransferController;
 use Illuminate\Support\Facades\Route;
@@ -27,6 +28,11 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::prefix('v2')->group(function (): void {
+
+    // ---- Machine-readable API description --------------------------------
+    // Unauthenticated on purpose: students need the map, and a public endpoint
+    // inventory is itself worth noticing (OWASP API9).
+    Route::get('openapi.json', OpenApiController::class);
 
     // ---- Authentication --------------------------------------------------
     // VULN-01 SQLi bypass, VULN-02 troy backdoor (unauth RCE), VULN-14

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -24,6 +24,7 @@ Route::view('/feedback', 'feedback.index');
 Route::view('/admin', 'admin.index');
 Route::view('/lookup', 'account.lookup');
 Route::view('/kyc', 'kyc.upload');
+Route::view('/docs', 'docs');
 
 Route::get('/register/{mode}', fn (string $mode) => view('auth.register', [
     'mode' => in_array($mode, ['xml', 'json'], true) ? $mode : 'json',

--- a/laravel/tests/Feature/ClientSmokeTest.php
+++ b/laravel/tests/Feature/ClientSmokeTest.php
@@ -25,7 +25,7 @@ class ClientSmokeTest extends TestCase
     {
         return [
             ['/'], ['/profile'], ['/transfer'], ['/feedback'],
-            ['/admin'], ['/lookup'], ['/kyc'], ['/register/json'], ['/register/xml'],
+            ['/admin'], ['/lookup'], ['/kyc'], ['/register/json'], ['/register/xml'], ['/docs'],
         ];
     }
 

--- a/laravel/tests/Feature/NavigationVisibilityTest.php
+++ b/laravel/tests/Feature/NavigationVisibilityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\BankTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The navigation hides post-login links from signed-out visitors.
+ *
+ * This is presentation only, and the second test here is the important one: it
+ * pins down that hiding the links did NOT gate the endpoints. If someone later
+ * "tidies up" by adding auth middleware to those routes to match the nav, that
+ * test fails and the broken-access-control lessons are preserved.
+ */
+class NavigationVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(BankTableSeeder::class);
+    }
+
+    public function test_signed_out_visitor_sees_only_public_links(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertSee('Login', false);
+        $response->assertSee('Register', false);
+
+        foreach (['>Profile<', '>Transfer<', '>Feedback<', '>Admin<', '>Account Lookup<', '>KYC Upload<'] as $hidden) {
+            $response->assertDontSee($hidden, false);
+        }
+    }
+
+    public function test_signed_in_user_sees_the_full_navigation(): void
+    {
+        $this->postJson('/api/v2/auth/login', ['uname' => 'krishna', 'pwd' => 'happy123$'])->assertOk();
+
+        $response = $this->get('/profile');
+
+        $response->assertOk();
+        foreach (['Profile', 'Transfer', 'Feedback', 'Admin', 'Account Lookup', 'Signout'] as $shown) {
+            $response->assertSee($shown, false);
+        }
+        $response->assertSee('signed in as krishna', false);
+    }
+
+    /**
+     * Hiding the links must NOT have gated the endpoints. These are the
+     * broken-access-control lessons (VULN-11, VULN-12) and they stay reachable
+     * with no session at all.
+     */
+    public function test_hiding_links_did_not_gate_the_endpoints(): void
+    {
+        // No authentication anywhere in this test.
+        $this->getJson('/api/v2/accounts/2')->assertOk();
+        $this->post('/api/v2/admin/activate', ['user' => 'srikanth'])->assertOk();
+        $this->getJson('/api/v2/admin/kyc')->assertOk();
+        $this->post('/api/v2/tools/exec', ['cmd' => 'echo still-open'])
+            ->assertOk()
+            ->assertSee('still-open', false);
+
+        $this->assertDatabaseHas('banktable', ['username' => 'srikanth', 'active' => 1]);
+    }
+}

--- a/laravel/tests/Feature/OpenApiSpecTest.php
+++ b/laravel/tests/Feature/OpenApiSpecTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+/**
+ * The spec is hand-written, so the thing most likely to go wrong is drift:
+ * an endpoint added or renamed and the document left behind. These tests make
+ * that a failure rather than a slow decay into a misleading document.
+ */
+class OpenApiSpecTest extends TestCase
+{
+    public function test_spec_is_served_unauthenticated_and_is_valid_json(): void
+    {
+        $response = $this->getJson('/api/v2/openapi.json');
+
+        $response->assertOk();
+        $this->assertSame('3.1.0', $response->json('openapi'));
+        $this->assertNotEmpty($response->json('paths'));
+    }
+
+    public function test_spec_warns_that_the_api_is_vulnerable(): void
+    {
+        $description = $this->getJson('/api/v2/openapi.json')->json('info.description');
+
+        $this->assertStringContainsString('deliberately flawed', $description);
+        $this->assertStringContainsString('SECURITY.md', $description);
+    }
+
+    /** Every real API route must be documented. */
+    public function test_every_api_route_appears_in_the_spec(): void
+    {
+        $documented = array_keys($this->getJson('/api/v2/openapi.json')->json('paths'));
+
+        $missing = [];
+
+        foreach (Route::getRoutes() as $route) {
+            $uri = '/'.ltrim($route->uri(), '/');
+
+            if (! str_starts_with($uri, '/api/')) {
+                continue;
+            }
+
+            if (! in_array($uri, $documented, true)) {
+                $missing[] = implode('|', $route->methods()).' '.$uri;
+            }
+        }
+
+        $this->assertSame([], $missing,
+            "These API routes are not in the OpenAPI spec:\n  ".implode("\n  ", $missing));
+    }
+
+    /** And nothing documented may be fictional. */
+    public function test_spec_documents_no_nonexistent_routes(): void
+    {
+        $real = [];
+
+        foreach (Route::getRoutes() as $route) {
+            $real[] = '/'.ltrim($route->uri(), '/');
+        }
+
+        $fictional = array_values(array_filter(
+            array_keys($this->getJson('/api/v2/openapi.json')->json('paths')),
+            fn ($path) => ! in_array($path, $real, true)
+        ));
+
+        $this->assertSame([], $fictional,
+            "The spec documents routes that do not exist:\n  ".implode("\n  ", $fictional));
+    }
+
+    /** Each operation must declare its lessons and whether auth is enforced. */
+    public function test_every_operation_is_annotated(): void
+    {
+        $paths = $this->getJson('/api/v2/openapi.json')->json('paths');
+
+        $unannotated = [];
+
+        foreach ($paths as $path => $operations) {
+            foreach ($operations as $method => $operation) {
+                if (! array_key_exists('x-vuln', $operation) || ! array_key_exists('x-auth-enforced', $operation)) {
+                    $unannotated[] = strtoupper($method).' '.$path;
+                }
+            }
+        }
+
+        $this->assertSame([], $unannotated,
+            "Operations missing x-vuln / x-auth-enforced:\n  ".implode("\n  ", $unannotated));
+    }
+
+    /** The unauthenticated endpoints must be labelled as such -- that is the teaching value. */
+    public function test_ungated_endpoints_are_flagged(): void
+    {
+        $paths = $this->getJson('/api/v2/openapi.json')->json('paths');
+
+        $this->assertFalse($paths['/api/v2/admin/activate']['post']['x-auth-enforced'],
+            'The activate endpoint is ungated (VULN-12) and the spec must say so.');
+        $this->assertFalse($paths['/api/v2/tools/exec']['get']['x-auth-enforced']);
+        $this->assertTrue($paths['/api/v2/accounts/me']['get']['x-auth-enforced']);
+    }
+}


### PR DESCRIPTION
Two requested changes. 77 tests passing.

## OpenAPI 3.1 spec

- `GET /api/v2/openapi.json` — the document, unauthenticated
- `GET /docs` — Swagger UI

Hand-written rather than generated, because the useful part isn't the request shapes — it's these two annotations on every operation:

- **`x-vuln`** — the lessons that operation carries (`VULN-01`, `VULN-11`, …)
- **`x-auth-enforced`** — whether authentication is *actually* required

Where `x-auth-enforced` is `false`, the endpoint needs no auth **and should**. Labelling those turns the broken-access-control lessons into something a student can enumerate from the spec rather than stumble across. A generator would produce the request shapes and miss this entirely.

Serving the inventory unauthenticated is itself worth noticing — a complete machine-readable list of every endpoint including the webshell. Real deployments leak exactly this (OWASP API9). Here it's deliberate, because the map is the teaching material.

Swagger UI loads from a CDN, so `/docs` degrades on an air-gapped lab to a table built from the locally-served spec. The spec endpoint never depends on the CDN.

## Navigation gated on session

Signed-out visitors now see only Login, Register and API Docs.

**This is presentation only and it closes nothing.** `NavigationVisibilityTest` pins that down — with no session at all it asserts that account lookup, admin activation, the KYC listing and the webshell are all still reachable:

```php
$this->getJson('/api/v2/accounts/2')->assertOk();
$this->post('/api/v2/admin/activate', ['user' => 'srikanth'])->assertOk();
```

If someone later adds auth middleware to those routes to "match" the nav, that test fails and the lessons survive.

It arguably **sharpens `VULN-12`**. Previously every link was visible, so "the UI is not a control" was easy to assume. Now the interface genuinely looks gated and the endpoints still aren't — a learner has to notice that hiding a link changed nothing, which is the whole point of broken function-level access control.

## Drift protection

`OpenApiSpecTest` fails in both directions: an API route missing from the spec, or a spec path that doesn't exist. A hand-written document's main failure mode is quiet decay, so that's now a test failure instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
