### PR TITLE
Add single-container Docker image and document both variants

### DIFF
--- a/README
+++ b/README
@@ -27,12 +27,66 @@ To get started with PHPVulnBank, follow these steps:
 
 4. Access the PHPVulnBank application through your web browser.
 
-## phpvulnbank on docker
+## Two versions live in this repository
 
-Go to command prompt and run below command.
-docker run -it -p 8090:80 -p 22:22  krishnapadala55/phpvulnbank:25.04
+| | |
+|---|---|
+| `src/` | The **original** flat-PHP application. Kept for reference and for before/after scanner comparison. |
+| `laravel/` | The **current** application: a Laravel 13 port with the same vulnerabilities, an API-first design, and a deliberately vulnerable MCP layer. |
+
+Full catalogue of what is intentional: [`docs/vulnerabilities.md`](docs/vulnerabilities.md).
+Read [`SECURITY.md`](SECURITY.md) before running either.
+
+## Running the Laravel version on Docker
+
+**Single container** (Apache + PHP + MariaDB together — one command, nothing else needed):
+
+```
+docker build -f laravel/Dockerfile.bundled -t phpvulnbank-laravel:bundled-vulnerable-1.0 laravel/
+docker run -it -p 8090:80 phpvulnbank-laravel:bundled-vulnerable-1.0
+```
+
+**Compose** (database in its own service — the better architecture, and the primary path):
+
+```
+cd laravel && docker compose up -d
+```
+
+Then open **http://localhost:8090**.
+
+| | |
+|---|---|
+| Web app | `/` |
+| API docs (Swagger UI) | `/docs` |
+| OpenAPI spec | `/api/v2/openapi.json` |
+| MCP over HTTP | `POST /mcp/api`, `POST /mcp/db` |
+| MCP over stdio | `php artisan mcp:start phpvulnbank-api` |
+
+Logins: `krishna` / `happy123$` (user), `admin` / `krishna1$` (administrator).
+
+Rebuild the lab data at any time — including after a student drops the database
+through the intentionally unrestricted SQL tool:
+
+```
+docker compose exec app php artisan migrate:fresh --seed --force
+```
+
+### Running the legacy version
+
+```
+docker run -it -p 8090:80 -p 22:22 krishnapadala55/phpvulnbank:25.04
+```
 
 [![PHPVulnBank Demo](docker_phpvulnbank.gif)](https://github.com/krishnareddypadala/phpvulnbank/blob/master/Media/docker_phpvulnbank.gif)
+
+## Where it is safe to run this
+
+This application contains **unauthenticated remote code execution**. Reaching its
+port is equivalent to shell access on the container.
+
+Fine on an isolated lab VLAN, a classroom network, or a LAN you control. **Never**
+on a public IP, a cloud VM with an open security group, a corporate network, a
+port-forwarded router, or through a tunnelling service. See [`SECURITY.md`](SECURITY.md).
 
 
 ## Contributing

--- a/laravel/Dockerfile.bundled
+++ b/laravel/Dockerfile.bundled
@@ -1,0 +1,54 @@
+# PHPVulnBank (Laravel) -- SINGLE-CONTAINER variant.
+#
+# Apache + PHP + MariaDB in one image, so the lab starts with one command:
+#
+#     docker run -it -p 8090:80 <image>
+#
+# This exists for parity with the legacy image, which bundled everything and is
+# what the README's published tags do. The compose setup (Dockerfile +
+# docker-compose.yml) remains the primary path and keeps the database in its own
+# service, which is the better architecture.
+#
+# Running two services in one container is not best practice. It is a
+# deliberate convenience for a disposable training lab, not a pattern to copy.
+#
+# Pinned by minor version. NEVER use `latest`, and never push without
+# `vulnerable` in the tag name. See ../SECURITY.md.
+FROM php:8.3-apache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libzip-dev libpng-dev libicu-dev libxml2-dev unzip git \
+        mariadb-server mariadb-client \
+    && docker-php-ext-install pdo_mysql zip gd intl dom \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Document root is public/ -- the correct configuration. Pointing it at the
+# project root instead is VULN-37 and is deliberately NOT enabled here.
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+RUN sed -ri 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' \
+        /etc/apache2/sites-available/*.conf /etc/apache2/apache2.conf \
+    && a2enmod rewrite
+
+WORKDIR /var/www/html
+COPY . /var/www/html
+
+RUN composer install --no-interaction --prefer-dist --no-progress \
+    && chown -R www-data:www-data /var/www/html
+
+# VULN-04 depends on PHP being EXECUTED in the uploads directory, which is the
+# default under mod_php. That is what makes an uploaded .php file a webshell.
+RUN mkdir -p public/images && chown -R www-data:www-data public/images
+
+# The MCP guard requires this to be set deliberately. Baking it into the
+# single-container image is the operator's opt-in by way of choosing to run it.
+ENV PHPVULNBANK_LAB=1
+
+COPY docker-entrypoint-bundled.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint-bundled.sh
+
+VOLUME /var/lib/mysql
+
+EXPOSE 80
+CMD ["/usr/local/bin/docker-entrypoint-bundled.sh"]

--- a/laravel/docker-entrypoint-bundled.sh
+++ b/laravel/docker-entrypoint-bundled.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+# LF line endings required -- see ../.gitattributes.
+#
+# Entrypoint for the SINGLE-CONTAINER variant: brings up MariaDB inside this
+# container, then the app. See Dockerfile.bundled.
+set -e
+
+DB_NAME="bankdb"
+DB_USER="groot"
+DB_PASS='bose123$'
+
+# ---------------------------------------------------------------------------
+# MariaDB
+# ---------------------------------------------------------------------------
+if [ ! -d /var/lib/mysql/mysql ]; then
+    echo "Initialising MariaDB data directory..."
+    mariadb-install-db --user=mysql --datadir=/var/lib/mysql >/dev/null 2>&1
+fi
+
+chown -R mysql:mysql /var/lib/mysql
+
+echo "Starting MariaDB..."
+mysqld_safe --user=mysql >/dev/null 2>&1 &
+
+i=0
+until mariadb -uroot -e 'select 1' >/dev/null 2>&1; do
+    i=$((i + 1))
+    if [ "$i" -ge 60 ]; then
+        echo "MariaDB failed to start."
+        exit 1
+    fi
+    sleep 1
+done
+
+# The legacy schema granted this account ALL PRIVILEGES ON *.* WITH GRANT
+# OPTION. That is VULN-22, and it is also the foundation of the direct-database
+# MCP lesson (VULN-91), so it is reproduced rather than tightened.
+mariadb -uroot <<SQL
+create database if not exists \`${DB_NAME}\`;
+create user if not exists '${DB_USER}'@'%' identified by '${DB_PASS}';
+create user if not exists '${DB_USER}'@'localhost' identified by '${DB_PASS}';
+grant all privileges on *.* to '${DB_USER}'@'%' with grant option;
+grant all privileges on *.* to '${DB_USER}'@'localhost' with grant option;
+flush privileges;
+SQL
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+
+# Written into .env rather than relying on the environment reaching PHP: under
+# Apache + mod_php, container environment variables are visible to the CLI but
+# are NOT passed to PHP for web requests without an explicit PassEnv. That
+# mismatch would have migrations run against MariaDB while the web app quietly
+# fell back to the sqlite default in .env.example.
+set_env() {
+    key="$1"; val="$2"
+    [ -z "$val" ] && return 0
+    if grep -q "^${key}=" .env; then
+        sed -i "s|^${key}=.*|${key}=${val}|" .env
+    else
+        echo "${key}=${val}" >> .env
+    fi
+}
+
+set_env APP_ENV "${APP_ENV:-local}"
+set_env APP_DEBUG "${APP_DEBUG:-true}"
+set_env APP_URL "${APP_URL:-http://localhost:8090}"
+set_env DB_CONNECTION "mysql"
+set_env DB_HOST "127.0.0.1"
+set_env DB_PORT "3306"
+set_env DB_DATABASE "${DB_NAME}"
+set_env DB_USERNAME "${DB_USER}"
+set_env DB_PASSWORD "${DB_PASS}"
+set_env PHPVULNBANK_LAB "${PHPVULNBANK_LAB:-1}"
+
+php artisan key:generate --force --no-interaction
+
+echo "Building the lab..."
+php artisan migrate:fresh --seed --force --no-interaction
+
+# Hand the writable trees back to www-data. Every artisan command above ran as
+# root, and the first one to log creates storage/logs/laravel.log owned
+# root:root -- after which Apache workers cannot append to it and ANY request
+# that logs anything returns 500. Invisible until something logs, and the error
+# points at logging rather than at ownership.
+chown -R www-data:www-data storage bootstrap/cache 2>/dev/null || true
+
+CONTAINER_IPS="$(hostname -i 2>/dev/null || echo 'unknown')"
+
+cat <<BANNER
+
+################################################################################
+#                                                                              #
+#   PHPVulnBank (Laravel)  --  INTENTIONALLY VULNERABLE TRAINING APPLICATION   #
+#                          single-container build                              #
+################################################################################
+
+  Listening on port 80 in this container. If you published it with
+  -p 8090:80 then it is on port 8090 of EVERY interface on the host.
+
+  Container address(es): ${CONTAINER_IPS}
+  Students connect to:   http://<THIS-HOST-LAN-IP>:8090
+  (run 'ip addr' or 'ipconfig' ON THE HOST -- the container cannot see it)
+
+  Web app:      http://<host>:8090
+  API docs:     http://<host>:8090/docs
+  OpenAPI spec: http://<host>:8090/api/v2/openapi.json
+  MCP (HTTP):   POST http://<host>:8090/mcp/api
+                POST http://<host>:8090/mcp/db
+
+  Logins:  krishna / happy123\$      admin / krishna1\$
+
+  --------------------------------------------------------------------------
+  WHAT ANYONE WHO CAN REACH THIS PORT CAN DO
+  --------------------------------------------------------------------------
+
+    * Run arbitrary shell commands as www-data, WITHOUT LOGGING IN.
+      Two paths: the 'troy' backdoor on the login endpoint (VULN-02) and
+      an unauthenticated webshell (VULN-03).
+    * Run arbitrary SQL through the unauthenticated MCP endpoint (VULN-80,
+      VULN-90) on a connection that can drop tables.
+    * Upload a file that then executes as code (VULN-04).
+    * Read arbitrary files from this container (VULN-07).
+    * Make this host issue requests to your internal network (VULN-08).
+
+    In short: reaching this port is equivalent to shell access on this
+    container. Treat a running instance as already compromised.
+
+  --------------------------------------------------------------------------
+  WHERE THIS IS OK, AND WHERE IT IS NOT
+  --------------------------------------------------------------------------
+
+    OK      an isolated lab VLAN, a classroom or workshop network,
+            a home LAN you control
+
+    NEVER   a public IP address
+    NEVER   a cloud VM with an open security group
+    NEVER   a corporate or shared office network
+    NEVER   behind a port-forwarded router
+    NEVER   through ngrok, Cloudflare Tunnel or any similar service
+
+    Do not leave it running after the session.
+
+  If a student drops the database, rebuild it with:
+      docker exec <container> php artisan migrate:fresh --seed --force
+
+  See SECURITY.md.
+
+################################################################################
+
+BANNER
+
+exec apache2-foreground


### PR DESCRIPTION
The compose image **cannot run standalone** — `docker run` sits at "Waiting for MySQL" and exits, because the database is a separate service. Fine for compose, wrong for Docker Hub, where the existing published tags start with one command since the legacy image bundled everything.

## What's added

`laravel/Dockerfile.bundled` — Apache + PHP + MariaDB in one image:

```bash
docker run -it -p 8090:80 phpvulnbank-laravel:bundled-vulnerable-1.0
```

Verified on the VM, standalone, no other containers:

| Check | Result |
|---|---|
| Comes up unattended | ✓ |
| Seeded rows | 4 |
| `troy` RCE | `uid=33(www-data)` |
| IDOR + hash | returns admin's MD5 |
| MCP `/mcp/api` `/mcp/db` | 8 and 4 tools |
| `/docs` | 200 |

Compose stays the primary path — a separate database service is the better architecture. Two services in one container is a deliberate convenience for a disposable lab, and the Dockerfile says so rather than implying it's worth copying.

## Two details that matter

The entrypoint **reproduces** the legacy `ALL PRIVILEGES ON *.*` grant for `groot` rather than tightening it. That's `VULN-22`, and the direct-database MCP lesson (`VULN-91`, "read-only is a lie") depends on the connection genuinely being able to write.

It also carries both fixes that deploying taught us: `chown storage/` back to `www-data` after the root-run artisan commands, or any request that logs anything 500s; and LF line endings, verified on the VM, since CRLF gives "bad interpreter" in a Linux container.

## README

Now documents both variants, the endpoint table including MCP URLs, the reseed command for when a student drops the database through the intentionally unrestricted SQL tool, and where this is safe to run. Docker Hub renders the README on the image page, so it needed to describe what the image actually is before anything gets published.

## Not published

That still needs two things from you:

1. **`docker login`** — neither machine is authenticated, and I won't run it.
2. **A tag decision** — `latest` currently points at the legacy app. Overwriting it would silently swap the application out from under anyone already pulling `krishnapadala55/phpvulnbank`. Suggest `laravel-bundled-vulnerable-1.0` and leaving `latest` alone. Also worth deciding on multi-arch: the image is `amd64` only, so Apple Silicon gets emulation.

82 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
